### PR TITLE
Greatly improved netcat and general command-line tool conformity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/*.pyc
 *.egg-info
 .DS_Store
+build
+dist

--- a/wssh/__init__.py
+++ b/wssh/__init__.py
@@ -16,6 +16,8 @@ def main():
             help='start in listen mode, creating a server')
     parser.add_argument('-q', dest='quit_on_eof', metavar='secs', type=int,
             help='quit after EOF on stdin and delay of secs (0 allowed)')
+    parser.add_argument('-v', dest='verbosity', action='count',
+            help='verbose (use twice to be more verbose)')
     args = parser.parse_args()
 
     url = args.url

--- a/wssh/__init__.py
+++ b/wssh/__init__.py
@@ -28,9 +28,10 @@ def main():
         else:
             port = 80
 
-    if args.l:
-        server.listen(port, url.path)
-    else:
-        client.connect(url.hostname, port, url.path)
-
-    
+    try:
+        if args.l:
+            server.listen(port, url.path)
+        else:
+            client.connect(url.hostname, port, url.path)
+    except KeyboardInterrupt:
+        pass

--- a/wssh/__init__.py
+++ b/wssh/__init__.py
@@ -1,4 +1,7 @@
 import sys
+if 'threading' in sys.modules:
+    raise Exception('threading module loaded before patching!')
+import gevent.monkey; gevent.monkey.patch_thread()
 from urlparse import urlparse
 
 from . import client

--- a/wssh/__init__.py
+++ b/wssh/__init__.py
@@ -12,9 +12,9 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('url', metavar='URL', type=str,
             help='URL of a WebSocket endpoint with or without ws:// or wss://')
-    parser.add_argument('-l', action='store_true', 
+    parser.add_argument('-l', dest='listen', action='store_true', 
             help='start in listen mode, creating a server')
-    parser.add_argument('-q', metavar='secs', type=int,
+    parser.add_argument('-q', dest='quit_on_eof', metavar='secs', type=int,
             help='quit after EOF on stdin and delay of secs (0 allowed)')
     args = parser.parse_args()
 
@@ -31,7 +31,7 @@ def main():
             port = 80
 
     try:
-        if args.l:
+        if args.listen:
             server.listen(args, port, url.path)
         else:
             client.connect(args, url.hostname, port, url.path)

--- a/wssh/__init__.py
+++ b/wssh/__init__.py
@@ -18,9 +18,16 @@ def main():
         url = "ws://{}".format(url)
     url = urlparse(url)
 
+    port = url.port
+    if port == None:
+        if url.scheme == "wss":
+            port = 443
+        else:
+            port = 80
+
     if args.l:
-        server.listen(url.port, url.path)
+        server.listen(port, url.path)
     else:
-        client.connect(url.hostname, url.port, url.path)
+        client.connect(url.hostname, port, url.path)
 
     

--- a/wssh/__init__.py
+++ b/wssh/__init__.py
@@ -3,17 +3,19 @@ if 'threading' in sys.modules:
     raise Exception('threading module loaded before patching!')
 import gevent.monkey; gevent.monkey.patch_thread()
 from urlparse import urlparse
+import argparse
 
 from . import client
 from . import server
 
 def main():
-    import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('url', metavar='URL', type=str,
             help='URL of a WebSocket endpoint with or without ws:// or wss://')
     parser.add_argument('-l', action='store_true', 
             help='start in listen mode, creating a server')
+    parser.add_argument('-q', metavar='secs', type=int,
+            help='quit after EOF on stdin and delay of secs (0 allowed)')
     args = parser.parse_args()
 
     url = args.url
@@ -30,8 +32,8 @@ def main():
 
     try:
         if args.l:
-            server.listen(port, url.path)
+            server.listen(args, port, url.path)
         else:
-            client.connect(url.hostname, port, url.path)
+            client.connect(args, url.hostname, port, url.path)
     except KeyboardInterrupt:
         pass

--- a/wssh/client.py
+++ b/wssh/client.py
@@ -1,3 +1,5 @@
+import sys
+
 import gevent
 from gevent.event import Event
 
@@ -28,4 +30,4 @@ def connect(host, port, path='/'):
     try:
         client.connect_and_wait()
     except (IOError, HandshakeError), e:
-        print e
+        print >> sys.stderr, e

--- a/wssh/client.py
+++ b/wssh/client.py
@@ -22,6 +22,9 @@ class StdioPipedWebSocketClient(WebSocketClient):
         self.iohelper.received_message(self, m)
 
     def opened(self):
+        if self.opts.verbosity >= 1:
+            peername, peerport = self.sock.getpeername()
+            print >> sys.stderr, "[%s] %d open" % (peername, peerport)
         self.iohelper.opened(self)
 
     def closed(self, code, reason):

--- a/wssh/common.py
+++ b/wssh/common.py
@@ -1,0 +1,34 @@
+import sys
+import os
+import fcntl
+
+import gevent
+from gevent.socket import wait_read
+
+from ws4py.websocket import WebSocket
+
+# Common stdio piping behaviour for the WebSocket handler.  Unfortunately due
+# to ws4py OO failures, it's not possible to just share a common WebSocket
+# class for this (WebSocketClient extends WebSocket, rather than simply
+# delegating to one as WebSocketServer can).
+
+def received_message(websocket, m):
+    sys.stdout.write(m.data)
+    sys.stdout.flush()
+
+def opened(websocket):
+    def connect_stdin():
+        fcntl.fcntl(sys.stdin, fcntl.F_SETFL, os.O_NONBLOCK)
+        while True:
+            wait_read(sys.stdin.fileno())
+            line = sys.stdin.readline()
+            if not line:
+                break
+            websocket.send(line)
+        # stdin has been closed, but we'll keep the websocket open regardless
+        # per netcat's behaviour.  This makes it much easier to use standard
+        # shell script piping along with this tool.
+
+    # XXX: We wait for the socket to open before reading stdin so that we
+    # support behaviour like: echo foo | wssh -l ...
+    gevent.spawn(connect_stdin)

--- a/wssh/common.py
+++ b/wssh/common.py
@@ -21,10 +21,11 @@ def opened(websocket):
         fcntl.fcntl(sys.stdin, fcntl.F_SETFL, os.O_NONBLOCK)
         while True:
             wait_read(sys.stdin.fileno())
-            line = sys.stdin.readline()
-            if not line:
+            buf = sys.stdin.read(4096)
+            if len(buf) == 0:
                 break
-            websocket.send(line)
+            # XXX: Always send the data as binary, regardless of what it really is.
+            websocket.send(buf, True)
         # stdin has been closed, but we'll keep the websocket open regardless
         # per netcat's behaviour.  This makes it much easier to use standard
         # shell script piping along with this tool.

--- a/wssh/common.py
+++ b/wssh/common.py
@@ -11,25 +11,33 @@ from ws4py.websocket import WebSocket
 # to ws4py OO failures, it's not possible to just share a common WebSocket
 # class for this (WebSocketClient extends WebSocket, rather than simply
 # delegating to one as WebSocketServer can).
+class StdioPipedWebSocketHelper:
+    def __init__(self, shutdown_cond, opts):
+        self.shutdown_cond = shutdown_cond
+        self.opts = opts
 
-def received_message(websocket, m):
-    sys.stdout.write(m.data)
-    sys.stdout.flush()
+    def received_message(self, websocket, m):
+        sys.stdout.write(m.data)
+        sys.stdout.flush()
 
-def opened(websocket):
-    def connect_stdin():
-        fcntl.fcntl(sys.stdin, fcntl.F_SETFL, os.O_NONBLOCK)
-        while True:
-            wait_read(sys.stdin.fileno())
-            buf = sys.stdin.read(4096)
-            if len(buf) == 0:
-                break
-            # XXX: Always send the data as binary, regardless of what it really is.
-            websocket.send(buf, True)
-        # stdin has been closed, but we'll keep the websocket open regardless
-        # per netcat's behaviour.  This makes it much easier to use standard
-        # shell script piping along with this tool.
+    def opened(self, websocket):
+        def connect_stdin():
+            fcntl.fcntl(sys.stdin, fcntl.F_SETFL, os.O_NONBLOCK)
+            while True:
+                wait_read(sys.stdin.fileno())
+                buf = sys.stdin.read(4096)
+                if len(buf) == 0:
+                    break
+                # XXX: Always send the data as binary, regardless of what it really is.
+                websocket.send(buf, True)
+            # If -q was passed, shutdown the program after EOF and the
+            # specified delay.  Otherwise, keep the socket open even with no
+            # more input flowing (consistent with netcat's behaviour).
+            if self.opts.q is not None:
+                if self.opts.q > 0:
+                    gevent.sleep(self.opts.q)
+                self.shutdown_cond.set()
 
-    # XXX: We wait for the socket to open before reading stdin so that we
-    # support behaviour like: echo foo | wssh -l ...
-    gevent.spawn(connect_stdin)
+        # XXX: We wait for the socket to open before reading stdin so that we
+        # support behaviour like: echo foo | wssh -l ...
+        gevent.spawn(connect_stdin)

--- a/wssh/common.py
+++ b/wssh/common.py
@@ -33,9 +33,9 @@ class StdioPipedWebSocketHelper:
             # If -q was passed, shutdown the program after EOF and the
             # specified delay.  Otherwise, keep the socket open even with no
             # more input flowing (consistent with netcat's behaviour).
-            if self.opts.q is not None:
-                if self.opts.q > 0:
-                    gevent.sleep(self.opts.q)
+            if self.opts.quit_on_eof is not None:
+                if self.opts.quit_on_eof > 0:
+                    gevent.sleep(self.opts.quit_on_eof)
                 self.shutdown_cond.set()
 
         # XXX: We wait for the socket to open before reading stdin so that we

--- a/wssh/server.py
+++ b/wssh/server.py
@@ -1,3 +1,5 @@
+import sys
+
 import gevent
 from gevent.event import Event
 
@@ -65,9 +67,14 @@ class SimpleWebSocketServer(gevent.pywsgi.WSGIServer):
 
     def handle_one_websocket(self):
         self.start()
+        if self.opts.verbosity >= 1:
+            print >> sys.stderr, 'listening on [any] %d...' % self.port
         self.shutdown_cond.wait()
 
 def listen(args, port, path=None):
     # XXX: Should add support to limit the listening interface.
     server = SimpleWebSocketServer('', port, path, args)
-    server.handle_one_websocket()
+    try:
+        server.handle_one_websocket()
+    except IOError, e:
+        print >> sys.stderr, e

--- a/wssh/server.py
+++ b/wssh/server.py
@@ -1,39 +1,62 @@
-import sys
-import os
-import fcntl
 import gevent
-from gevent.socket import wait_read
-from urlparse import urlparse
+from gevent.event import Event
 
-import gevent
+from ws4py.server.geventserver import UpgradableWSGIHandler
+from ws4py.server.wsgi.middleware import WebSocketUpgradeMiddleware
+from ws4py.websocket import WebSocket
 
-from ws4py.exc import HandshakeError
-from ws4py.server.geventserver import WebSocketServer
+from . import common
 
-def handler(path):
-    def handle(websocket, environ):
-        if path and environ.get('PATH_INFO', '') != path:
-            websocket.close()
-            return
-        def incoming():
-            while True:
-                msg = websocket.receive()
-                if msg is not None:
-                    print msg
-                else:
-                    websocket.close()
-        def outgoing():
-            fcntl.fcntl(sys.stdin, fcntl.F_SETFL, os.O_NONBLOCK)
-            while True:
-                wait_read(sys.stdin.fileno())
-                line = sys.stdin.readline()
-                websocket.send(line.strip())
-        gevent.joinall([
-            gevent.spawn(incoming),
-            gevent.spawn(outgoing),
-        ])
-    return handle
+# Handles the WebSocket once it has been upgraded by the HTTP layer.
+class StdioPipedWebSocket(WebSocket):
+    def received_message(self, m):
+        common.received_message(self, m)
+
+    def opened(self):
+        common.opened(self)
+
+    def closed(self, code, reason):
+        pass
+
+# Simple HTTP server implementing only one endpoint which upgrades to the
+# stdin/stdout connected WebSocket.
+class SimpleWebSocketServer(gevent.pywsgi.WSGIServer):
+    handler_class = UpgradableWSGIHandler
+
+    def __init__(self, host, port, path):
+        gevent.pywsgi.WSGIServer.__init__(self, (host, port), log=None)
+
+        self.path = path
+        self.application = self
+        self.shutdown_cond = Event()
+
+        self.ws_upgrade = WebSocketUpgradeMiddleware(app=self.ws_handler,
+                websocket_class=StdioPipedWebSocket)
+
+    def __call__(self, environ, start_response):
+        if self.path and environ['PATH_INFO'] != self.path:
+            start_response('400 Not Found', [])
+        else:
+            # Hand-off the WebSocket upgrade negotiation to ws4py...
+            return self.ws_upgrade(environ, start_response)
+
+    def ws_handler(self, websocket):
+        # Stop accepting new connections after we receive our first one (a la
+        # netcat).
+        self.stop_accepting()
+
+        # Transfer control to the websocket_class.
+        g = gevent.spawn(websocket.run)
+        g.join()
+
+        # WebSocket connection terminated, exit program.
+        self.shutdown_cond.set()
+
+    def handle_one_websocket(self):
+        self.start()
+        self.shutdown_cond.wait()
 
 def listen(port, path=None):
-    server = WebSocketServer(('', port), handler(path))
-    server.serve_forever()
+    # XXX: Should add support to limit the listening interface.
+    server = SimpleWebSocketServer('', port, path)
+    server.handle_one_websocket()


### PR DESCRIPTION
Hi, I've made a number of changes (broadly rewrote client and server.py) that generally improve the tools status as a netcat-like command-line websocket utility.  

Internally I did a bunch of work to integrate more naturally with ws4py and gevent, reduce output noise, and serve only a single connection before exiting (like netcat does).  I also made significant changes to support scripting (specifically using the tools with pipes), all of which designed to match netcat's interface.
