### PR TITLE
Enable running on Python versions earlier than 2.7

### DIFF
--- a/wssh/__init__.py
+++ b/wssh/__init__.py
@@ -22,7 +22,7 @@ def main():
 
     url = args.url
     if not url.startswith("ws://") and not url.startswith("wss://"):
-        url = "ws://{}".format(url)
+        url = "ws://{0}".format(url)
     url = urlparse(url)
 
     # Apply an appropriate default port.

--- a/wssh/client.py
+++ b/wssh/client.py
@@ -12,7 +12,7 @@ from . import common
 class StdioPipedWebSocketClient(WebSocketClient):
 
     def __init__(self, host, port, path, opts):
-        url = "ws://{}:{}{}".format(host, port, path)
+        url = "ws://{0}:{1}{2}".format(host, port, path)
         WebSocketClient.__init__(self, url)
 
         self.path = path


### PR DESCRIPTION
I made a change so that wssh can run on python versions earlier than 2.7. Format strings with simply {} is not allowed before 2.7
