### PR TITLE
Added a -m option to control text vs binary frame encoding

### DIFF
--- a/wssh/__init__.py
+++ b/wssh/__init__.py
@@ -20,7 +20,7 @@ def main():
     parser.add_argument('-q', dest='quit_on_eof', metavar='secs', type=int,
             help='quit after EOF on stdin and delay of secs (0 allowed)')
     parser.add_argument('-v', dest='verbosity', action='count',
-            help='verbose (use twice to be more verbose)')
+            help='verbose (use up to 3 times to be more verbose)')
     args = parser.parse_args()
 
     url = args.url

--- a/wssh/__init__.py
+++ b/wssh/__init__.py
@@ -14,6 +14,9 @@ def main():
             help='URL of a WebSocket endpoint with or without ws:// or wss://')
     parser.add_argument('-l', dest='listen', action='store_true', 
             help='start in listen mode, creating a server')
+    parser.add_argument('-m', dest='text_mode', type=str, default='auto',
+            choices=['text', 'binary', 'auto'],
+            help='specify the message transmit mode (default: auto)')
     parser.add_argument('-q', dest='quit_on_eof', metavar='secs', type=int,
             help='quit after EOF on stdin and delay of secs (0 allowed)')
     parser.add_argument('-v', dest='verbosity', action='count',

--- a/wssh/common.py
+++ b/wssh/common.py
@@ -23,6 +23,9 @@ class StdioPipedWebSocketHelper:
             self.textset = set(c for c in string.printable if ord(c) < 128)
 
     def received_message(self, websocket, m):
+        if self.opts.verbosity >= 3:
+            mode_msg = 'binary' if m.is_binary else 'text'
+            print >> sys.stderr, "[received payload of length %d as %s]" % (len(m.data), mode_msg)
         sys.stdout.write(m.data)
         sys.stdout.flush()
 
@@ -43,6 +46,9 @@ class StdioPipedWebSocketHelper:
                 if len(buf) == 0:
                     break
                 binary=self.should_send_binary_frame(buf)
+                if self.opts.verbosity >= 3:
+                    mode_msg = 'binary' if binary else 'text'
+                    print >> sys.stderr, "[sending payload of length %d as %s]" % (len(buf), mode_msg)
                 websocket.send(buf, binary)
             # If -q was passed, shutdown the program after EOF and the
             # specified delay.  Otherwise, keep the socket open even with no


### PR DESCRIPTION
This changes the current default behaviour to use the auto mode (previously it was always sending binary frames).

Also adds significance to the third level of verbosity (-vvv) to print a message each time a frame is sent or received.  Useful for diagnostic purposes.
