### PR TITLE
Separate message by a new line

### DIFF
--- a/wssh/__init__.py
+++ b/wssh/__init__.py
@@ -17,6 +17,8 @@ def main():
     parser.add_argument('-m', dest='text_mode', type=str, default='auto',
             choices=['text', 'binary', 'auto'],
             help='specify the message transmit mode (default: auto)')
+    parser.add_argument('-n', dest='new_lines', action='store_true', 
+            help='separate each received message with a newline')
     parser.add_argument('-q', dest='quit_on_eof', metavar='secs', type=int,
             help='quit after EOF on stdin and delay of secs (0 allowed)')
     parser.add_argument('-v', dest='verbosity', action='count',

--- a/wssh/common.py
+++ b/wssh/common.py
@@ -27,6 +27,8 @@ class StdioPipedWebSocketHelper:
             mode_msg = 'binary' if m.is_binary else 'text'
             print >> sys.stderr, "[received payload of length %d as %s]" % (len(m.data), mode_msg)
         sys.stdout.write(m.data)
+        if self.opts.new_lines:
+          sys.stdout.write("\n")
         sys.stdout.flush()
 
     def should_send_binary_frame(self, buf):


### PR DESCRIPTION
Added an option to separate each new message by a newline.  This allows the output from wssh to become the input to other processes.
